### PR TITLE
pin github actions to commit SHAs

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@3235b876344d2a9aa001b8d1453c930bba69e610 # v3
         with:
           node-version: '18'
           registry-url: 'https://registry.npmjs.org/'


### PR DESCRIPTION
## Summary
- Pins all third-party GitHub Actions to full commit SHAs instead of mutable tags
- Prevents supply chain attacks via tag mutation (ref: tj-actions/changed-files incident, March 2025)
- Version comments preserved inline for readability

## Test plan
- [ ] CI passes (no functional change, just pinning)

🤖 Generated with [Claude Code](https://claude.com/claude-code)